### PR TITLE
Add Redmi 9

### DIFF
--- a/infos.json
+++ b/infos.json
@@ -949,5 +949,22 @@
             "key_ims_request_network": "true",
             "key_ims_force_enable_setting": "true"
         }
+    },
+    {
+        "match_property": "vendor_fp",
+        "match_value": "Redmi/lancelot*|Redmi/galahad*",
+        "device_name": "Redmi 9",
+
+        "maintainer": {
+            "name": "WingBack433"
+        },
+        "community": {
+            "telegram": "https://t.me/phhtreble"
+        },
+        "preferences": {
+            "key_misc_backlight_scale": true,
+            "key_misc_bluetooth": "mediatek",
+            "xiaomi_double_tap_to_wake": true
+        }
     }
 ]


### PR DESCRIPTION
For those of you who are wondering why I didn't include `Rotation perf hint instead of touch`, `Mediatek GED KPI support` and/or `Disable SF GL backpressure`.

I've done 3DMark & Geekbench 6 benchmarks, here are the results:

**3DMark (Vulkan)**
Rotation perf hint instead of touch enabled: `671`
Mediatek GED KPI support enabled: `672`
Disable SF GL backpressure enabled: `668`
The 3 options above disabled: `674`

**Geekbench CPU**
Rotation perf hint instead of touch enabled: `Single 415` | `Multi 1365`
Mediatek GED KPI support enabled: `Single 416` | `Multi 1363`
Disable SF GL backpressure enabled: `Single 414` | `Multi 1374`
The 3 options above disabled: `Single 414` | `Multi 1379`

**Geekbench GPU (OpenCL)**
Rotation perf hint instead of touch enabled: `1110`
Mediatek GED KPI support enabled: `1112`
Disable SF GL backpressure enabled: `1109`
The 3 options above disabled: `1116`

**Geekbench GPU (Vulkan)**
Rotation perf hint instead of touch enabled: `1080`
Mediatek GED KPI support enabled: `1084`
Disable SF GL backpressure enabled: `1076`
The 3 options above disabled: `1090`

Note: _Reboot is performed before benchmarking_

I also didn't include the IMS (VoLTE) preference, I feel it's better for you to enable it yourself.

Hopefully what I'm doing is right.