### PR TITLE
Update Redmi 9 presets

### DIFF
--- a/infos.json
+++ b/infos.json
@@ -956,7 +956,7 @@
         "device_name": "Redmi 9",
 
         "maintainer": {
-            "name": "wildbeetle"
+            "name": "no one"
         },
         "community": {
             "telegram": "https://t.me/phhtreble"
@@ -964,9 +964,7 @@
         "preferences": {
             "xiaomi_double_tap_to_wake": true,
             "key_misc_disable_audio_effects": true,
-            "key_misc_display_fps": "0",
-            "key_misc_mediatek_touch_hint_rotate": true,
-            "key_misc_mediatek_ged_kpi": true,
+            "key_misc_disable_sf_hwc_backpressure": true,
             "key_misc_backlight_scale": true,
             "key_misc_bluetooth": "mediatek"
         }


### PR DESCRIPTION
* Disable key_misc_display_fps = not needed.
* Disable key_misc_mediatek_touch_hint_rotate = doesn't have much effect.
* Disable key_misc_mediatek_ged_kpi = causes benchmark scores to decrease.
* Enable key_misc_disable_sf_hwc_backpressure = fix lag.
* Remove wildbeetle from the maintainer of Redmi 9

Test:
* First remove all debugging stuff from rw-system.sh
* Manual test one by one