### PR TITLE
 Update Redmi 9 presets

### DIFF
--- a/infos.json
+++ b/infos.json
@@ -964,6 +964,7 @@
         "preferences": {
             "xiaomi_double_tap_to_wake": true,
             "key_misc_disable_audio_effects": true,
+            "key_misc_mediatek_touch_hint_rotate": true,
             "key_misc_disable_sf_hwc_backpressure": true,
             "key_misc_backlight_scale": true,
             "key_misc_bluetooth": "mediatek"


### PR DESCRIPTION
Update description:

Enable key_misc_mediatek_touch_hint_rotate = fix lag in games.

Fix graphic lag.
Fix control responsiveness.

Tested on Beach Buggy Racing.

**It also helps rendering when screen brightness is high which makes rendering a bit heavy.**

Sorry yesterday I didn't do a game test.
it turns out `key_misc_mediatek_touch_hint_rotate` is useful in games.