### PR TITLE
add infnix hot 30 (X6831) preset

### DIFF
--- a/infos.json
+++ b/infos.json
@@ -969,5 +969,37 @@
             "key_misc_backlight_scale": true,
             "key_misc_bluetooth": "mediatek"
         }
-    }
+    },
+    {
+        "match_property": "vendor_fp",
+        "match_value": ".*Infinix\/X6831.*",
+        "device_name": "Infinix Hot 30",
+        "maintainer": {
+          "name": "fluentmoheshwar"
+        },
+        "community": {
+          "telegram": "https://t.me/phhtreble"
+        },
+        "preferences": {
+          "key_transsion_usb_otg": true,
+          "key_transsion_dt2w": true,
+          "key_doze_handwave": true,
+          "key_doze_pocket": true,
+          "key_misc_headset_devinput": true,
+          "key_misc_disable_audio_effects": true,
+          "key_misc_mediatek_touch_hint_rotate": true,
+          "key_misc_mediatek_ged_kp": true,
+          "key_misc_disable_sf_gl_backpressure": true,
+          "key_misc_disable_sf_hwc_backpressure": true,
+          "key_misc_force_camera2api_hal3": true,
+          "key_misc_dynamic_sysbta": true,
+          "key_misc_allow_binder_thread_on_incoming_calls": true,
+          "key_misc_disable_voice_call_in": true,
+          "key_misc_bluetooth": "mediatek",
+          "key_ims_request_network": true,
+          "key_ims_create_apn": true,
+          "key_ims_force_enable_setting": true,
+          "key_ims_install_apn": true
+        }
+      }     
 ]


### PR DESCRIPTION
## Transsion Features: 

- Enable DT2W (For double tap to wake, uses more battery) 
- Enable USB OTG (for OTG) 

## Doze Features: 

- Enable Handwave Gesture 
- Enable Out-of-pocket gesture

## Misc Features: 

- Use alternate way to detect headset. (fixes headset)
- Disable Audio Effects (Fixes calling and microphone issues in few apps, breaks audio in VLC though) 
- Force FPS > 1080x2460@90.0 (For 90hz)
- Rotation perf hint instead of touch. (improves performance)
- MediaTek GED KPI Support (improves performance)
- Disable SF GL Backpressure (improves performance)
- Disable SF HWC Backpressure (improves performance)
- Force enable Camera2API HAL3 (improves camera)
- Use System wide BT HAL (fixes BT)
- Allow binder thread on incoming call. (fixes VoLTE)
- Disable "Voice Call In" Route (fixes VoLTE)

## IMS Features: 

- Create IMS APN (fixes VoLTE)
- Install IMS APK for MediaTek R+ vendor (fixes VoLTE)
- Request IMS Network (fixes VoLTE)
- Force presence of 4G calling (fixes VoLTE)